### PR TITLE
Fixing CacheNodeData serialization...

### DIFF
--- a/neural-network/neural_network.py
+++ b/neural-network/neural_network.py
@@ -44,7 +44,6 @@ class CachedNodeData:
         self.global_parameter_gradient = global_parameter_gradient
 
     def __repr__(self):
-        #return "{}".format(vars(self))
         return (
             "CachedNodeData(output=" + repr( self.output ) + ", " +
             "local_gradient=" + repr( self.local_gradient ) + ", " +

--- a/neural-network/neural_network.py
+++ b/neural-network/neural_network.py
@@ -35,15 +35,23 @@ class CachedNodeData:
     - global_parameter_gradient: [∂E/∂w_1, ∂E/∂w_2, ..., ∂E/∂w_k]
     '''
 
-    def __init__(self):
-        self.output = None
-        self.local_gradient = None
-        self.global_gradient = None
-        self.local_parameter_gradient = None
-        self.global_parameter_gradient = None
+    def __init__(self, output=None, local_gradient=None, global_gradient=None,
+                local_parameter_gradient=None, global_parameter_gradient=None):
+        self.output = output
+        self.local_gradient = local_gradient
+        self.global_gradient = global_gradient
+        self.local_parameter_gradient = local_parameter_gradient
+        self.global_parameter_gradient = global_parameter_gradient
 
     def __repr__(self):
-        return "{}".format(vars(self))
+        #return "{}".format(vars(self))
+        return (
+            "CachedNodeData(output=" + repr( self.output ) + ", " +
+            "local_gradient=" + repr( self.local_gradient ) + ", " +
+            "global_gradient=" + repr( self.global_gradient ) + ", " +
+            "local_parameter_gradient=" + repr( self.local_parameter_gradient ) + ", " +
+            "global_parameter_gradient=" + repr( self.global_parameter_gradient ) + ")"
+        )
 
 
 class Node:

--- a/neural-network/neural_network_test.py
+++ b/neural-network/neural_network_test.py
@@ -37,29 +37,16 @@ def test_cache_repr():
     cache.global_gradient = 3
     cache.local_parameter_gradient = 4
     cache.global_parameter_gradient = 5
-
-    #assert_that(repr(cache)).is_equal_to(
-        #"{'output': 1, "
-        #"'local_gradient': 2, "
-        #"'global_gradient': 3, "
-        #"'local_parameter_gradient': 4, "
-        #"'global_parameter_gradient': 5}")
-
-    assert_that(repr(cache)).is_equal_to(
+    expect = (
         "CachedNodeData(output=1, "
         "local_gradient=2, "
         "global_gradient=3, "
         "local_parameter_gradient=4, "
-        "global_parameter_gradient=5)")
-
+        "global_parameter_gradient=5)"
+    )
+    assert_that(repr(cache)).is_equal_to(expect)
     cache = eval(repr(cache))
-
-    assert_that(repr(cache)).is_equal_to(
-        "CachedNodeData(output=1, "
-        "local_gradient=2, "
-        "global_gradient=3, "
-        "local_parameter_gradient=4, "
-        "global_parameter_gradient=5)")
+    assert_that(repr(cache)).is_equal_to(expect)
 
 def test_linear_node_bad_initialization():
     input_nodes = InputNode.make_input_nodes(3)

--- a/neural-network/neural_network_test.py
+++ b/neural-network/neural_network_test.py
@@ -38,13 +38,28 @@ def test_cache_repr():
     cache.local_parameter_gradient = 4
     cache.global_parameter_gradient = 5
 
-    assert_that(repr(cache)).is_equal_to(
-        "{'output': 1, "
-        "'local_gradient': 2, "
-        "'global_gradient': 3, "
-        "'local_parameter_gradient': 4, "
-        "'global_parameter_gradient': 5}")
+    #assert_that(repr(cache)).is_equal_to(
+        #"{'output': 1, "
+        #"'local_gradient': 2, "
+        #"'global_gradient': 3, "
+        #"'local_parameter_gradient': 4, "
+        #"'global_parameter_gradient': 5}")
 
+    assert_that(repr(cache)).is_equal_to(
+        "CachedNodeData(output=1, "
+        "local_gradient=2, "
+        "global_gradient=3, "
+        "local_parameter_gradient=4, "
+        "global_parameter_gradient=5)")
+
+    cache = eval(repr(cache))
+
+    assert_that(repr(cache)).is_equal_to(
+        "CachedNodeData(output=1, "
+        "local_gradient=2, "
+        "global_gradient=3, "
+        "local_parameter_gradient=4, "
+        "global_parameter_gradient=5)")
 
 def test_linear_node_bad_initialization():
     input_nodes = InputNode.make_input_nodes(3)


### PR DESCRIPTION
Hey there. Had some issues with the lack of order of key/value pairs in Python v3.5 dict objects. I'm new to Python but also apparently output from repr() should be able to round-trip through eval() so I fixed that too... this is a breaking change for repr(CacheNodeData) but I expect that is not a big problem...